### PR TITLE
feat: support default theme styles

### DIFF
--- a/src/custom-addons/withThemes/Panel.tsx
+++ b/src/custom-addons/withThemes/Panel.tsx
@@ -9,11 +9,13 @@ interface IPanelProps {
 
 interface IPanelState {
   themeName: string;
+  defaultStyles: boolean;
 }
 
 export class Panel extends React.Component<IPanelProps, IPanelState> {
   public state = {
     themeName: sessionStorage.themeName || 'light',
+    defaultStyles: sessionStorage.themeDefaultStyles === 'true',
   };
 
   private setTheme = (themeName: string) => {
@@ -21,37 +23,54 @@ export class Panel extends React.Component<IPanelProps, IPanelState> {
     sessionStorage.themeName = themeName;
   };
 
+  private setDefaultStyles = (defaultStyles: boolean) => {
+    this.setState({ defaultStyles });
+    sessionStorage.themeDefaultStyles = defaultStyles;
+  };
+
   public componentDidMount() {
     const { channel } = this.props;
     // Listen to the theme and change it.
     channel.on('themes/setTheme', this.setTheme);
+    channel.on('themes/setDefaultStyles', this.setDefaultStyles);
   }
 
   public render() {
-    const { themeName } = this.state;
+    const { themeName, defaultStyles } = this.state;
     const { active, channel } = this.props;
 
     return active ? (
-      <div style={{ margin: 25, width: '100%', overflow: 'auto' }}>
-        {themes.map((theme: string) => (
-          <span
-            key={theme}
-            onClick={() => channel.emit('themes/setTheme', theme)}
-            style={{
-              display: 'inline-block',
-              padding: '5px 10px',
-              color: theme === themeName ? 'green' : undefined,
-              border: `1px solid ${theme === themeName ? '#ccc' : '#ddd'}`,
-              marginRight: 10,
-              cursor: theme === themeName ? 'default' : 'pointer',
-              background: theme === themeName ? '#eee' : 'transparent',
-              fontWeight: 'bold',
-              borderRadius: 3,
-            }}
-          >
-            {theme}
-          </span>
-        ))}
+      <div style={{ display: 'flex', flexFlow: 'column nowrap', padding: 25, width: '100%', overflow: 'auto' }}>
+        <div>
+          {themes.map((theme: string) => (
+            <span
+              key={theme}
+              onClick={() => channel.emit('themes/setTheme', theme)}
+              style={{
+                display: 'inline-block',
+                padding: '5px 10px',
+                color: theme === themeName ? 'green' : undefined,
+                border: `1px solid ${theme === themeName ? '#ccc' : '#ddd'}`,
+                marginRight: 10,
+                cursor: theme === themeName ? 'default' : 'pointer',
+                background: theme === themeName ? '#eee' : 'transparent',
+                fontWeight: 'bold',
+                borderRadius: 3,
+              }}
+            >
+              {theme}
+            </span>
+          ))}
+        </div>
+        <div style={{ marginTop: 20 }}>
+          <label htmlFor="default-styles">Inject theme.js' defaultThemeStyles?</label>
+          <input
+            id="default-styles"
+            type="checkbox"
+            checked={defaultStyles}
+            onChange={() => channel.emit('themes/setDefaultStyles', !defaultStyles)}
+          />
+        </div>
       </div>
     ) : null;
   }
@@ -59,6 +78,7 @@ export class Panel extends React.Component<IPanelProps, IPanelState> {
   // This is some cleanup tasks when the Notes panel is unmounting.
   public componentWillUnmount() {
     const { channel } = this.props;
-    channel.removeListener('setTheme', this.setTheme);
+    channel.removeListener('themes/setTheme', this.setTheme);
+    channel.removeListener('themes/setDefaultStyles', this.setDefaultStyles);
   }
 }

--- a/src/custom-addons/withThemes/index.tsx
+++ b/src/custom-addons/withThemes/index.tsx
@@ -2,7 +2,7 @@
 import addons, { makeDecorator } from '@storybook/addons';
 import * as React from 'react';
 
-const { ThemeProvider, zones } = require('@project/theme');
+const { ThemeProvider, zones, defaultThemeStyles } = require('@project/theme');
 
 interface IThemeContainerProps {
   channel: any;
@@ -11,6 +11,7 @@ interface IThemeContainerProps {
 
 interface IThemeContainerState {
   themeName: string;
+  defaultStyles: boolean;
 }
 
 export const withThemes = makeDecorator({
@@ -25,30 +26,39 @@ export const withThemes = makeDecorator({
 class ThemeContainer extends React.Component<IThemeContainerProps, IThemeContainerState> {
   public state = {
     themeName: sessionStorage.themeName || 'light',
+    defaultStyles: sessionStorage.themeDefaultStyles === 'true',
   };
 
   public componentDidMount() {
     const { channel } = this.props;
     channel.on('themes/setTheme', this.onThemeChange);
+    channel.on('themes/setDefaultStyles', this.onDefaultStyles);
   }
 
   public componentWillUnmount() {
     const { channel } = this.props;
     channel.removeListener('themes/setTheme', this.onThemeChange);
+    channel.removeListener('themes/setDefaultStyles', this.onDefaultStyles);
   }
 
   public onThemeChange = (themeName: string) => {
     this.setState({ themeName });
   };
 
+  public onDefaultStyles = (defaultStyles: boolean) => {
+    this.setState({ defaultStyles });
+  };
+
   public render() {
-    const { themeName } = this.state;
+    const { themeName, defaultStyles } = this.state;
     const { children } = this.props;
 
     return (
-      <ThemeProvider theme={{ base: themeName }} zones={zones}>
-        {children}
-      </ThemeProvider>
+      <div style={defaultStyles && defaultThemeStyles ? defaultThemeStyles[themeName] : null}>
+        <ThemeProvider theme={{ base: themeName }} zones={zones}>
+          {children}
+        </ThemeProvider>
+      </div>
     );
   }
 }


### PR DESCRIPTION
It was requested a couple of days ago by Will and IMHO it makes sense to have such a feature included given it was easy to implement.
In general, most of the satellite projects such as Formtron, Slate or Tree-List will inherit some styling.
At the moment, it's quite difficult to mimic such styles. The only way to do that is to wrap each story (global decorators cannot be used until Storybook v5 is released) with a decorator containing the styled component.
This may be annoying.

To make further styling easier, `defaultThemeStyles` has been introduced to the theme.js Storybook config.

You can put any CSS rule and it will be automatically injected into the theme wrapper as long as you have the checkbox ticket, i.e.

```ts
export const defaultThemeStyles = {
  dark: {
    backgroundColor: '#111',
    color: '#fff',
  },
  light: {
    backgroundColor: '#fff',
    color: '#111',
  }
};
```
![storybook2](https://user-images.githubusercontent.com/9273484/50784882-4522dc00-12af-11e9-80e8-0fcc0d366688.gif)

If styles are not present, nothing happens. The change is backward compatible meaning existing projects won't break if they don't export `defaultThemeStyles`.