### PR TITLE
fix: update deprecated config options [SL-2601]

### DIFF
--- a/src/addons.ts
+++ b/src/addons.ts
@@ -1,4 +1,3 @@
 require('@storybook/addon-knobs/register');
 require('@storybook/addon-actions/register');
 require('@storybook/addon-links/register');
-require('@storybook/addon-options/register');

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,19 +1,27 @@
-import { withOptions } from '@storybook/addon-options';
-import { addDecorator, configure } from '@storybook/react';
+import { addParameters, configure } from '@storybook/react';
+import { create } from '@storybook/theming';
 
-addDecorator(
-  withOptions({
-    name: pkg.name || 'Stoplight UI-Kit',
-    url: pkg.url || 'https://github.com/stoplightio/ui-kit',
-    goFullScreen: false,
-    showStoriesPanel: true,
-    showAddonPanel: true,
+// This is kinda fragile as it makes the assumptions that it is installed in
+// the top-level node_modules of the root project.
+const pkg = require('../../../package.json');
+
+addParameters({
+  options: {
+    isFullScreen: false,
+    showNav: true,
+    showPanel: true,
     showSearchBox: false,
-    addonPanelInRight: true,
+    panelPosition: 'right',
     sortStoriesByKind: true,
     selectedAddonPanel: undefined,
-  })
-);
+    theme: create({
+      base: 'light',
+
+      brandTitle: pkg.name,
+      brandUrl: pkg.repository.url,
+    }),
+  },
+});
 
 function loadStories() {
   require('@project/stories');


### PR DESCRIPTION
I also fixed the bug where the name was always 'Stoplight UI-Kit' because `pkg` is undefined. :/

# Before
![image](https://user-images.githubusercontent.com/587740/58647648-ffa29200-82d5-11e9-8ea0-89229d2049b5.png)

# After
![image](https://user-images.githubusercontent.com/587740/58647581-e26dc380-82d5-11e9-9fb0-2f97db669c4b.png)

# Testing notes
- `yarn build && (cd dist && yalc push)`
- try it with a repo, see if it works. I tested against `@stoplight/monaco` repo.