### PR TITLE
fix: addons being stripped from built storybook [STU-258]

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "description": "Shared storybook config for UI-Kit based project",
   "keywords": [],
-  "sideEffects": false,
   "homepage": "https://github.com/stoplightio/storybook-config",
   "bugs": "https://github.com/stoplightio/storybook-config/issues",
   "author": "Stoplight <support@stoplight.io>",


### PR DESCRIPTION
see https://github.com/stoplightio/monaco/pull/17 for an example using this updated config

See https://github.com/storybookjs/storybook/issues/6413#issuecomment-499260109